### PR TITLE
Feature/dsp 609 miller columns sluggish

### DIFF
--- a/app/modules/elements/controllers/elements-panels.controller.js
+++ b/app/modules/elements/controllers/elements-panels.controller.js
@@ -23,7 +23,7 @@
         _this.millercolumn.dataSelected = index;
         _this.millercolumn.level1Selected = null;
         cfpLoadingBar.complete();
-      }, 1500);
+      }, 750);
 
       // $log.debug(item);
     };


### PR DESCRIPTION
Per discussion with Carla, it is OK to show progress bar as we are simulating a network request for data. Reduced the delay by 50% so the "request" feels quicker.