### PR TITLE
fix angular translate examples

### DIFF
--- a/app/modules/foundation/templates/foundation-directives.html
+++ b/app/modules/foundation/templates/foundation-directives.html
@@ -92,7 +92,7 @@ angular.module('app', [
                     <td>label</td>
                     <td>string</td>
                     <td>none</td>
-                    <td>The text label for the checkbox input. When using localized strings with angular-translate, use <code>ng-attr-label</code> to handle the string inerpolation, example <code>ng-attr-label="&#123;&#123;'CHECKBOX' &#124; translate&#125;&#125;"</code></td>
+                    <td>The text label for the checkbox input.<br />The label attribute can be used with angular-translate, for example <code>label="&#123;&ZeroWidthSpace;&#123;'SOMETHING.LABEL' &#124; translate&#125;&ZeroWidthSpace;&#125;"</code></td>
                 </tr>
                 <tr>
                     <td>ng-model</td>
@@ -209,7 +209,7 @@ angular.module('app', [
                     <td>label</td>
                     <td>string</td>
                     <td>none</td>
-                    <td>The text label for the checkbox input. When using localized strings with angular-translate, use <code>ng-attr-label</code> to handle the string inerpolation, example <code>ng-attr-label="&#123;&#123;'CHECKBOX' &#124; translate&#125;&#125;"</code></td>
+                    <td>The text label for the checkbox input.<br />The label attribute can be used with angular-translate, for example <code>label="&#123;&ZeroWidthSpace;&#123;'SOMETHING.LABEL' &#124; translate&#125;&ZeroWidthSpace;&#125;"</code></td>
                 </tr>
                 <tr>
                     <td>ng-model</td>


### PR DESCRIPTION
fixed the translate examples, formatting was not showing the curly braces, pipe characters, etc.