### PR TITLE
check if selected date is today

### DIFF
--- a/app/modules/elements/controllers/elements-inputs.controller.js
+++ b/app/modules/elements/controllers/elements-inputs.controller.js
@@ -212,12 +212,22 @@
       displayDate: function (start, end) {
         var startDate = start || _this.daterangepicker3.date.startDate;
         var endDate = end || _this.daterangepicker3.date.endDate;
+        var today = moment();
 
         var dateDiff = endDate.diff(startDate, 'days');
         var result = '';
 
         if (dateDiff === 0) {
-          result = 'Today ' + moment(startDate).format('MM/DD/YYYY');
+          var isDaySame = startDate.isSame(today, 'day');
+          var isMonthSame = startDate.isSame(today, 'month');
+          var isYearSame = startDate.isSame(today, 'year');
+
+          // if the selected date is the same as today date, display "Today" in the result
+          if (isDaySame && isMonthSame && isYearSame) {
+            result = 'Today ' + moment(startDate).format('MM/DD/YYYY');
+          } else {
+            result = moment(startDate).format('MM/DD/YYYY');
+          }
         } else if (dateDiff === 6) {
           result = 'Last 7 days';
         } else {


### PR DESCRIPTION
fix for #132, if the daterange selected === today, then the 'Today' is shown in the string, else it only displays the date.

For example, if today is 3/3/16 and I select a start and end date of 4/4/16, the word 'Today' should not show. Currently 'Today' shows which is a bug.